### PR TITLE
Investigate netlify page not found errors

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,8 +5,8 @@
 [[plugins]]
   package = "@netlify/plugin-nextjs"
 
-# Redirect all to Next.js for best SPA support
+# Redirect all to Next.js server handler (Netlify Next.js Runtime v5)
 [[redirects]]
   from = "/*"
-  to = "/.netlify/functions/next"
+  to = "/.netlify/functions/___netlify-server-handler"
   status = 200


### PR DESCRIPTION
Update Netlify redirect to point to the correct Next.js server handler.

The previous redirect to `/.netlify/functions/next` was incorrect for Next.js Runtime v5, causing a 404 error on the deployed site despite a successful build. The updated redirect to `/.netlify/functions/___netlify-server-handler` ensures requests are routed to the correct serverless function.

---
<a href="https://cursor.com/background-agent?bcId=bc-632c5e7f-9673-4f6a-bf57-5e37dd2de0b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-632c5e7f-9673-4f6a-bf57-5e37dd2de0b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

